### PR TITLE
Rewrite the whole combinators module to use HRTB only where necessary.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,4 @@
+#![feature(core, unboxed_closures)]
+
 pub mod ast;
 pub mod parser;

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -1,40 +1,23 @@
-use parser::combinators::{TypeWithLifetime, Str, Unit, Function, Parser, StrParser, Consumer, ParserConsumer, string, character};
-use self::TokenAt::{LParen, RParen, Whitespace, Identifier};
+use parser::combinators::{Parser, StrParser, Consumer, ParserConsumer, string, character};
+use self::Token::{LParen, RParen, Whitespace, Identifier};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
-pub enum TokenAt<'a> {
+pub enum Token<'a> {
     LParen,
     RParen,
     Whitespace,
     Identifier(&'a str),
 }
 
-pub struct Token;
-
-impl<'a> TypeWithLifetime<'a> for Token {
-    type Type = TokenAt<'a>;
-}
-
-impl Function<Unit,Token> for TokenAt<'static> {
-    fn apply<'a>(&self, _: ()) -> TokenAt<'a> {
-        self.clone()
-    }
-}
-
-struct MkIdentifier;
-
-impl Function<Str,Token> for MkIdentifier {
-    fn apply<'a>(&self, name: &'a str) -> TokenAt<'a> {
-        Identifier(name)
-    }
-}
+fn mk_identifier<'a>(s: &'a str) -> Token<'a> { Identifier(s) }
 
 #[allow(non_snake_case)]
-pub fn lexer<C>(consumer: &mut C) where C: ParserConsumer<Str,Token> {
-    let LPAREN = string("(").map(LParen);
-    let RPAREN = string(")").map(RParen);
-    let WHITESPACE = character(char::is_whitespace).map(Whitespace);
-    let IDENTIFIER = character(char::is_alphabetic).and_then(character(char::is_alphanumeric).star()).buffer().map(MkIdentifier);
+pub fn lexer<C,D>(consumer: &mut C) where C: for<'a> ParserConsumer<&'a str,D>, D: for<'a> Consumer<Token<'a>> {
+    let LPAREN = string("(").map(|_| LParen);
+    let RPAREN = string(")").map(|_| RParen);
+    let WHITESPACE = character(char::is_whitespace).map(|_| Whitespace);
+    let IDENTIFIER = character(char::is_alphabetic).and_then(character(char::is_alphanumeric).star())
+                                                   .buffer().map(mk_identifier);
     let TOKEN = LPAREN.or_else(RPAREN).or_else(WHITESPACE).or_else(IDENTIFIER);
     consumer.accept(TOKEN.star())
 }
@@ -42,14 +25,15 @@ pub fn lexer<C>(consumer: &mut C) where C: ParserConsumer<Str,Token> {
 
 #[test]
 fn test_lexer() {
-    impl Consumer<Token> for Vec<TokenAt<'static>> {
-        fn accept<'a>(&mut self, token: TokenAt<'a>) {
+    use parser::combinators::ParseTo;
+    impl<'a> Consumer<Token<'a>> for Vec<Token<'static>> {
+        fn accept(&mut self, token: Token<'a>) {
             assert_eq!(self.remove(0), token);
         }
     }
     struct TestConsumer;
-    impl ParserConsumer<Str,Token> for TestConsumer {
-        fn accept<P>(&mut self, mut lex: P) where P: Parser<Str,Token> {
+    impl<'a> ParserConsumer<&'a str, Vec<Token<'static>>> for TestConsumer {
+        fn accept<P>(&mut self, mut lex: P) where P: ParseTo<&'a str,Vec<Token<'static>>> {
             let mut tokens = vec![LParen, Identifier("a123"), Whitespace, Whitespace, Identifier("bcd"), RParen];
             lex.push_to("(a123  bcd)", &mut tokens);
             assert_eq!(tokens, []);


### PR DESCRIPTION
Most of the changes are straight-forward, except for the `Fn<(T,)>` workaround for rust-lang/rust#30867, which requires the two feature-gates.
